### PR TITLE
docs: Fix simple typo, tranlated -> translated

### DIFF
--- a/spillway/query.py
+++ b/spillway/query.py
@@ -108,7 +108,7 @@ class GeoQuerySet(query.QuerySet):
         return geo_field(self)
 
     def pbf(self, bbox, geo_col=None, scale=4096):
-        """Returns tranlated and scaled geometries suitable for Mapbox vector
+        """Returns translated and scaled geometries suitable for Mapbox vector
         tiles.
         """
         col = geo_col or self.geo_field.name


### PR DESCRIPTION
There is a small typo in spillway/query.py.

Should read `translated` rather than `tranlated`.

