### PR TITLE
Moving away from deprecated django features

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Django==1.11.22
 djangorestframework==3.9.4
 greenwich==0.8.0
+six==1.16.0

--- a/spillway/collections.py
+++ b/spillway/collections.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import collections
 
-from django.utils import six
+import six
 from greenwich.srs import SpatialReference
 
 from spillway.compat import json, JSONEncoder

--- a/spillway/forms/fields.py
+++ b/spillway/forms/fields.py
@@ -4,7 +4,7 @@ import shutil
 import tempfile
 import zipfile
 
-from django.utils.six.moves import reduce
+from six.moves import reduce
 from django.contrib.gis import forms, gdal
 from django.contrib.gis.db.models import functions
 from django.contrib.gis.gdal.srs import SpatialReference, SRSException

--- a/spillway/forms/fields.py
+++ b/spillway/forms/fields.py
@@ -8,7 +8,7 @@ from six.moves import reduce
 from django.contrib.gis import forms, gdal
 from django.contrib.gis.db.models import functions
 from django.contrib.gis.gdal.srs import SpatialReference, SRSException
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from greenwich.geometry import Envelope
 from rest_framework import renderers
 

--- a/spillway/models.py
+++ b/spillway/models.py
@@ -7,7 +7,7 @@ if six.PY3:
     buffer = memoryview
 from django.contrib.gis.db import models
 from django.utils.deconstruct import deconstructible
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 import greenwich
 from greenwich.io import MemFileIO
 import numpy as np

--- a/spillway/models.py
+++ b/spillway/models.py
@@ -2,7 +2,7 @@ import os
 import datetime
 import tempfile
 
-from django.utils import six
+import six
 if six.PY3:
     buffer = memoryview
 from django.contrib.gis.db import models

--- a/spillway/query.py
+++ b/spillway/query.py
@@ -9,7 +9,7 @@ from django.db.models import query
 from django.contrib.gis import geos
 import django.contrib.gis.db.models.functions as geofn
 from django.contrib.gis.db import models
-from django.utils import six
+import six
 from django.utils.functional import cached_property
 import numpy as np
 

--- a/spillway/query.py
+++ b/spillway/query.py
@@ -82,7 +82,7 @@ class GeoQuerySet(query.QuerySet):
         if connection.ops.spatialite:
             return geofn.Scale(geofn.Translate(colname, deltax, deltay), xfactor, yfactor)
         else:
-            return TransScale(colname, deltax, deltay, xfactor, yfactor)
+            return TransScale(colname, deltax, deltay, xfactor, yfactor, output_field=models.MultiPolygonField())
 
     def extent(self, srid=None):
         """Returns the GeoQuerySet extent as a 4-tuple.
@@ -150,7 +150,7 @@ class GeoQuerySet(query.QuerySet):
         if clip:
             bufbox = bbox.buffer(tilew)
             sql = geofn.Intersection(sql, bufbox.envelope)
-        sql = SimplifyPreserveTopology(sql, tilew)
+        sql = SimplifyPreserveTopology(sql, tilew, output_field=models.MultiPolygonField())
         if format == 'pbf':
             return clone.pbf(bbox, geo_col=sql)
         sql = geofn.Transform(sql, 4326)

--- a/spillway/validators.py
+++ b/spillway/validators.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.utils.deconstruct import deconstructible
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 @deconstructible

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,7 +3,7 @@ import os
 import operator
 import tempfile
 
-from django.utils.six.moves import reduce
+from six.moves import reduce
 from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db.models.fields.files import FieldFile


### PR DESCRIPTION
This patch moves away from some functions and libraries that were deprecated in Django. This includes: 

`six` not being a vendored package anymore
`ugettext_lazy` being deprecated in favor of `gettext_lazy`

This makes the library usable in newer versions of Django. 

This patch also fixes the mixed types error, allowing us to go beyond Django 3.1 :) 